### PR TITLE
Ensure GUI App loads configuration with a preset

### DIFF
--- a/autotest.py
+++ b/autotest.py
@@ -856,7 +856,7 @@ def main():
     try:
         # Instantiate main.App() - this should create MainWindow but not show it by default
         # if App is designed to not show GUI unless app.main_window.show() is called.
-        app_instance = App()
+        app_instance = App(preset_name=cli_args.preset)
     except Exception as e:
         logger.error(f"Failed to initialize main.App: {e}", exc_info=True)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- update `App` to accept optional preset overrides, derive a saved or bundled fallback, and pass the chosen preset into `Configuration`
- track the preset used for initialization and improve GUI launch argument handling
- pass the CLI preset into the GUI smoke test harness so it boots with the desired preset

## Testing
- `python autotest.py --gui-smoke` *(fails: missing libGL in container)*
- `python -m compileall main.py autotest.py`


------
https://chatgpt.com/codex/tasks/task_e_68cab1ab1ed4833181879c38635ef604